### PR TITLE
Fix sending to the hologram

### DIFF
--- a/holo.lua
+++ b/holo.lua
@@ -79,8 +79,8 @@ local loc = {
 -- Try to load a component safely
 local function trytofind(name)
   name = tostring(name)
-  if com.isAvailable(holoName) then
-    return com.getPrimary(holoName)
+  if com.isAvailable(name) then
+    return com.getPrimary(name)
   else
     return com.proxy(tostring(name))
   end


### PR DESCRIPTION
A missing variable declaration meant it crashed when sending to the hologram

This bug is present in both the oppm and hpm package managers